### PR TITLE
Add package data export and script generation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ Create backup? (y/n): y
 Proceed? (yes): yes
 ```
 
+## Export package data
+
+Generate a consolidated JSON file with all bloatware package information from every supported brand:
+
+```bash
+python scripts/generate_data_bundle.py
+```
+
+This creates `build/data.json` containing:
+- All package names, descriptions, and risk levels
+- Brand/platform associations
+- Category classifications (adware, telemetry, OEM tools)
+- Metadata (generation timestamp, package counts)
+
+Use this data for:
+- Custom tooling and automation
+- Package analysis and research
+- Integration with other debloating workflows
+- Creating custom removal scripts
+
 ## Important stuff
 
 - **Always backup first** - Things can go wrong

--- a/scripts/generate_data_bundle.py
+++ b/scripts/generate_data_bundle.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Iterable
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+BRANDS = [
+    ("Samsung", "Samsung.samsung_remover", "SamsungRemover"),
+    ("Xiaomi", "Xiaomi.xiaomi_remover", "XiaomiRemover"),
+    ("Oppo", "Oppo.oppo_remover", "OppoRemover"),
+    ("Vivo", "Vivo.vivo_remover", "VivoRemover"),
+    ("Realme", "Realme.realme_remover", "RealmeRemover"),
+    ("Tecno", "Tecno.tecno_remover", "TecnoRemover"),
+    ("OnePlus", "OnePlus.oneplus_remover", "OnePlusRemover"),
+    ("Huawei", "Huawei.huawei_remover", "HuaweiRemover"),
+    ("Honor", "Honor.honor_remover", "HonorRemover"),
+    ("Motorola", "Motorola.motorola_remover", "MotorolaRemover"),
+    ("Nothing", "Nothing.nothing_remover", "NothingRemover"),
+    ("Asus", "Asus.asus_remover", "AsusRemover"),
+    ("Google", "Google.google_remover", "GoogleRemover"),
+    ("Infinix", "Infinix.infinix_remover", "InfinixRemover"),
+    ("Lenovo", "Lenovo.lenovo_remover", "LenovoRemover"),
+]
+
+CATEGORY_OVERRIDES: dict[tuple[str, str] | str, str] = {
+    ("samsung", "carrier_bloat"): "adware",
+    ("samsung", "google_apps"): "telemetry",
+    "ads": "adware",
+    "preloads": "oem_tool",
+    "gaming": "oem_tool",
+    "services": "telemetry",
+    "assistant": "telemetry",
+    "pixel_features": "oem_tool",
+    "system_tools": "oem_tool",
+    "media": "adware",
+}
+
+RISK_SCORES = {"safe": 1, "caution": 2, "dangerous": 3, "unknown": 0}
+
+
+def load_packages() -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for brand_title, module_path, class_name in BRANDS:
+        module = import_module(module_path)
+        cls = getattr(module, class_name)
+        remover = cls(test_mode=True)
+        config = remover._get_default_packages()
+        categories: dict[str, Iterable[dict[str, Any]]] = config.get("categories", {})
+        for category_key, packages in categories.items():
+            for item in packages:
+                package_name = item.get("name")
+                if not package_name:
+                    continue
+                risk = item.get("risk", "unknown").lower()
+                risk_score = RISK_SCORES.get(risk, 0)
+                description = item.get("description", "")
+                normalized_category = category_key.replace("_", " ").title()
+                group = CATEGORY_OVERRIDES.get((brand_title.lower(), category_key.lower()))
+                if not group:
+                    group = CATEGORY_OVERRIDES.get(category_key.lower(), "oem_tool")
+                entries.append(
+                    {
+                        "brand": brand_title,
+                        "platform": brand_title,
+                        "package": package_name,
+                        "description": description,
+                        "risk": risk,
+                        "risk_score": risk_score,
+                        "category": normalized_category,
+                        "category_slug": category_key,
+                        "category_group": group,
+                    }
+                )
+    entries.sort(key=lambda row: (row["brand"], row["category"], row["package"]))
+    return entries
+
+
+def write_json(payload: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate consolidated bloatware dataset")
+    parser.add_argument("--out", default="build/data.json")
+    parser.add_argument("--public", default="web/public/data.json")
+    args = parser.parse_args()
+
+    packages = load_packages()
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "package_count": len(packages),
+        "brands": sorted({entry["brand"] for entry in packages}),
+        "category_groups": sorted({entry["category_group"] for entry in packages}),
+        "risks": RISK_SCORES,
+        "packages": packages,
+    }
+
+    primary_path = Path(args.out)
+    public_path = Path(args.public)
+    write_json(payload, primary_path)
+    write_json(payload, public_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generators/adb.py
+++ b/scripts/generators/adb.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+def generate(packages: Iterable[str], *, device_serial: Optional[str] = None) -> str:
+    pkg_list = [pkg.strip() for pkg in packages if pkg.strip()]
+    if not pkg_list:
+        return "# No packages selected"
+
+    prefix = f"adb -s {device_serial} shell" if device_serial else "adb shell"
+    lines = ["# Run these commands in a terminal"]
+    for pkg in pkg_list:
+        lines.append(f"{prefix} pm uninstall --user 0 {pkg}")
+    return "\n".join(lines)

--- a/scripts/generators/bash.py
+++ b/scripts/generators/bash.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+def generate(packages: Iterable[str], *, device_serial: Optional[str] = None) -> str:
+    pkg_list = [pkg.strip() for pkg in packages if pkg.strip()]
+    if not pkg_list:
+        return "# No packages selected"
+
+    prefix = f"adb -s {device_serial} " if device_serial else "adb "
+    lines: list[str] = []
+    lines.append("#!/usr/bin/env bash")
+    lines.append("set -euo pipefail")
+    lines.append("packages=(")
+    lines.extend(f'    "{pkg}"' for pkg in pkg_list)
+    lines.append(")")
+    lines.append("errors=()")
+    lines.append("for pkg in \"${packages[@]}\"; do")
+    lines.append(f"    if ! {prefix}shell pm uninstall --user 0 \"$pkg\" >/dev/null 2>&1; then")
+    lines.append(f"        if ! {prefix}shell pm disable-user --user 0 \"$pkg\" >/dev/null 2>&1; then")
+    lines.append("            errors+=(\"$pkg\")")
+    lines.append("        fi")
+    lines.append("    fi")
+    lines.append("done")
+    lines.append("if [ ${#errors[@]} -gt 0 ]; then")
+    lines.append("    printf 'Failed to process\\n'")
+    lines.append("    for pkg in \"${errors[@]}\"; do")
+    lines.append("        printf ' - %s\\n' \"$pkg\"")
+    lines.append("    done")
+    lines.append("else")
+    lines.append("    echo 'All packages processed successfully.'")
+    lines.append("fi")
+    return "\n".join(lines)

--- a/scripts/generators/powershell.py
+++ b/scripts/generators/powershell.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+def generate(packages: Iterable[str], *, device_serial: Optional[str] = None) -> str:
+    pkg_list = [pkg.strip() for pkg in packages if pkg.strip()]
+    if not pkg_list:
+        return "# No packages selected"
+
+    serial = f" -s {device_serial}" if device_serial else ""
+    lines: list[str] = []
+    lines.append("$packages = @(")
+    lines.extend(f'    "{pkg}"' for pkg in pkg_list)
+    lines.append(")")
+    lines.append("$errors = @()")
+    lines.append("foreach ($pkg in $packages) {")
+    lines.append(f"    $result = adb{serial} shell pm uninstall --user 0 $pkg")
+    lines.append("    if ($LASTEXITCODE -ne 0 -or -not $result.Contains('Success')) {")
+    lines.append(f"        $fallback = adb{serial} shell pm disable-user --user 0 $pkg")
+    lines.append("        if ($LASTEXITCODE -ne 0) {")
+    lines.append("            $errors += $pkg")
+    lines.append("        }")
+    lines.append("    }")
+    lines.append("}")
+    lines.append("if ($errors.Count -gt 0) {")
+    lines.append("    Write-Output 'Failed to process:'")
+    lines.append("    $errors | ForEach-Object { Write-Output (\" - $_\") }")
+    lines.append("} else {")
+    lines.append("    Write-Output 'All packages processed successfully.'")
+    lines.append("}")
+    return "\n".join(lines)


### PR DESCRIPTION
Introduces tooling to export bloatware package data in structured formats for automation and integration.

Includes a data bundle generator that extracts package information from all brand removers and outputs consolidated JSON with metadata, risk classifications, and category groupings.

Also provides script generators for ADB shell commands, Bash scripts, and PowerShell scripts to enable custom removal workflows.